### PR TITLE
Ignore webkit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ This will:
 `$env:UPDATE_BASELINE="1"; npx playwright test tests/diffArticlesAgainstBaseline.spec.js`
 `$env:UPDATE_BASELINE="1"; npx playwright test tests/diffAmendmentsAgainstBaseline.spec.js`
 
+### 6️⃣ Troubleshooting
+
+#### Ignore WebKit tests
+
+If, in your machine, Playwright is not compatible with WebKit, you can ignore WebKit tests with
+`IGNORE_WEBKIT=1 npx playwight test ...`
+
 ## 📋 Example Diff Report
 ### Diff Report: article-3
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,42 @@
 // @ts-check
 import { defineConfig, devices } from '@playwright/test';
 
+const configProjects = [
+  {
+    name: "chromium",
+    use: { ...devices["Desktop Chrome"] },
+  },
+
+  {
+    name: "firefox",
+    use: { ...devices["Desktop Firefox"] },
+  },
+
+  {
+    name: "webkit",
+    use: { ...devices["Desktop Safari"] },
+  },
+  /* Test against mobile viewports. */
+  // {
+  //   name: 'Mobile Chrome',
+  //   use: { ...devices['Pixel 5'] },
+  // },
+  // {
+  //   name: 'Mobile Safari',
+  //   use: { ...devices['iPhone 12'] },
+  // },
+
+  /* Test against branded browsers. */
+  // {
+  //   name: 'Microsoft Edge',
+  //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+  // },
+  // {
+  //   name: 'Google Chrome',
+  //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+  // },
+];
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -34,42 +70,7 @@ export default defineConfig({
   },
 
   /* Configure projects for major browsers */
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
-  ],
+  projects: process.env.IGNORE_WEBKIT === "1" ? configProjects.slice(0, 2) : configProjects,
 
   /* Run your local dev server before starting the tests */
   // webServer: {


### PR DESCRIPTION
## Context

My machine has Ubuntu 24.04.1 installed  and is not able to run Playwright tests with WebKit: throwing an internal error related to "load" event. 

## Changes
This PR contains the following:
- Allows playwright configuration to ignore WebKit tests if the environmental variable `IGNORE_WEBKIT=1` is present
- Project README file updated